### PR TITLE
Exclude node_modules from importing css modules

### DIFF
--- a/src/webpack/config.js
+++ b/src/webpack/config.js
@@ -67,11 +67,22 @@ export function webpackConfig(env) {
           options: {
             localIdentName: '[name]__[local]___[hash:base64:5]',
             sourceMap: true,
-            modules: true,
             importLoaders: 1,
           },
         },
-        'postcss-loader',
+        {
+          loader: 'postcss-loader',
+          options: {
+            plugins: () => [
+              // eslint-disable-next-line global-require
+              require('postcss-cssnext')({
+                // If you don't set this, you get the GB preset default,
+                // which is fine in most cases
+                browsers: process.env.BROWSER_SUPPORT,
+              }),
+            ],
+          },
+        },
       ],
     },
     {

--- a/src/webpack/config.js
+++ b/src/webpack/config.js
@@ -59,6 +59,23 @@ export function webpackConfig(env) {
     },
     {
       test: /\.css$/,
+      exclude: /node_modules/,
+      use: [
+        'style-loader',
+        {
+          loader: 'css-loader',
+          options: {
+            localIdentName: '[name]__[local]___[hash:base64:5]',
+            sourceMap: true,
+            modules: true,
+            importLoaders: 1,
+          },
+        },
+        'postcss-loader',
+      ],
+    },
+    {
+      test: /\.css$/,
       use: [
         'style-loader',
         {

--- a/src/webpack/config.js
+++ b/src/webpack/config.js
@@ -136,14 +136,21 @@ export function webpackConfig(env) {
 
   if (isProd) {
     // fix loaders for prod
-    const [, cssLoader] = loaders;
+    const [, thirdPartyCssLoader, cssLoader] = loaders;
+    const { use: [thirdPartyStyle, ...thirdPartyRest] } = thirdPartyCssLoader;
     const { use: [style, ...rest] } = cssLoader;
+
+    const thirdPartyExtract = ExtractTextPlugin.extract({
+      fallback: thirdPartyStyle,
+      use: thirdPartyRest,
+    });
 
     const extract = ExtractTextPlugin.extract({
       fallback: style,
       use: rest,
     });
 
+    thirdPartyCssLoader.use = thirdPartyExtract;
     cssLoader.use = extract;
 
     // fix plugins for prod

--- a/src/webpack/config.js
+++ b/src/webpack/config.js
@@ -59,7 +59,7 @@ export function webpackConfig(env) {
     },
     {
       test: /\.css$/,
-      exclude: /node_modules/,
+      include: /node_modules/,
       use: [
         'style-loader',
         {
@@ -76,6 +76,7 @@ export function webpackConfig(env) {
     },
     {
       test: /\.css$/,
+      exclude: /node_modules/,
       use: [
         'style-loader',
         {


### PR DESCRIPTION
In the consumer-web project, we're attempting to [import a CSS file](https://github.com/gas-buddy/consumer-web/blob/master/src/common/containers/station/index.js#L2) from node_modules, but the default behavior is to import the file using CSS Modules, which effectively namespaces class names. We had to override the loaders in the import statement and tell ESLint to ignore the behavior. We should assume that a CSS file coming from node_modules should not be namespaced and should be globally applicable.