### PR TITLE
Ignore some built-ins; version patch

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gasbuddy/web-dev",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "GasBuddy Platform for Web Projects - Dev time dependencies",
   "main": "build/index.js",
   "module": "src/index.js",

--- a/src/webpack/config.js
+++ b/src/webpack/config.js
@@ -12,6 +12,11 @@ export function webpackConfig(env) {
 
   // These paths are relative to CWD, which is expected to be package root
   const config = {
+    node: {
+      fs: 'empty',
+      net: 'empty',
+      tls: 'empty',
+    },
     devtool: '#inline-source-map',
     entry: {
       client: path.resolve('./src/client'),


### PR DESCRIPTION
Not sure why or how... but when using some npm modules, which rely on these builtins, the webpack config (in starter-web, as an example) would issue an error such as `Module not found: Error: Can't resolve 'tls'`. 

These resolves that, at least on a develop-mode project. Changes may need to be made to make something production-ready.

But this PR is worth discussion.