### PR TITLE
Set allChunks to true for ExtractTextPlugin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@gasbuddy/web-dev",
-  "version": "7.5.0",
+  "version": "7.5.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gasbuddy/web-dev",
-  "version": "7.5.0",
+  "version": "7.5.1",
   "description": "GasBuddy Platform for Web Projects - Dev time dependencies",
   "main": "build/index.js",
   "module": "src/index.js",

--- a/src/webpack/config.js
+++ b/src/webpack/config.js
@@ -129,7 +129,10 @@ export function webpackConfig(env) {
 
     // fix plugins for prod
     plugins.push(
-      new ExtractTextPlugin(isProd ? '[name].[chunkhash].css' : '[name].bundle.css'),
+      new ExtractTextPlugin({
+        filename: isProd ? '[name].[chunkhash].css' : '[name].bundle.css',
+        allChunks: true,
+      }),
     );
 
     // other opts


### PR DESCRIPTION
We have our consumer-web project very close to serving page-specific bundles/chunks. The issue we're running into is discussed in https://github.com/webpack-contrib/extract-text-webpack-plugin/issues/456. Chunking CSS doesn't work because errors are thrown when trying to import `style-loader/addStyles` and `css-loader/lib/css-base`. I tried just adding those files to our vendor array, but it didn't seem to work, so I'm proposing we avoid chunking CSS for now.