### PR TITLE
Fix generating css.map

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@gasbuddy/web-dev",
-  "version": "9.1.0",
+  "version": "9.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gasbuddy/web-dev",
-  "version": "9.1.0",
+  "version": "9.1.1",
   "description": "GasBuddy Platform for Web Projects - Dev time dependencies",
   "main": "build/index.js",
   "module": "src/index.js",

--- a/src/webpack/config.js
+++ b/src/webpack/config.js
@@ -123,7 +123,11 @@ export function webpackConfig(env) {
         parallel: true,
         sourceMap: true,
       }),
-      new OptimizeCSSAssetsPlugin({}),
+      new OptimizeCSSAssetsPlugin({
+        cssProcessorOptions: {
+          inline: false,
+        },
+      }),
     ];
 
     // fix plugins for prod


### PR DESCRIPTION
After upgrading `tracker-web` to babel7 and `web-dev@9.1.0` I found `css.map` was not generating.

I found [a github issue](https://github.com/NMFR/optimize-css-assets-webpack-plugin/issues/53#issuecomment-393132666) which states if `MiniCssExtractPlugin` and `OptimizeCSSAssetsPlugin` are used together than `OptimizeCssAssetsPlugin` needs to configured differently so that css.map would generate. (The solution works though if [filenames are configured properly](https://github.com/NMFR/optimize-css-assets-webpack-plugin/issues/53#issuecomment-396224830), which in our case works fine.)

I made changes to `node_modules/@gasbuddy/web-dev` locally and verify I could generate css.map correctly.

Here is the result:

<img width="732" alt="screenshot 2018-11-16 11 06 36" src="https://user-images.githubusercontent.com/19353311/48636172-c89b0d80-e98f-11e8-8523-e056c9a91350.png">