### PR TITLE
Remove babel exclusions

### DIFF
--- a/src/webpack/config.js
+++ b/src/webpack/config.js
@@ -1,7 +1,6 @@
 import path from 'path';
 import webpack from 'webpack';
 // eslint-disable-next-line import/no-extraneous-dependencies
-import ignore from 'babel-preset-gasbuddy/ignore';
 import ManifestPlugin from 'webpack-manifest-plugin';
 import MiniCssExtractPlugin from 'mini-css-extract-plugin';
 import UglifyJsPlugin from 'uglifyjs-webpack-plugin';
@@ -60,8 +59,6 @@ export function webpackConfig(env) {
   const rules = [
     {
       test: /\.js$/,
-      // This is necessary to get the babel-polyfill to be minimized
-      exclude: ignore,
       use: [
         {
           loader: 'babel-loader',


### PR DESCRIPTION
The `ignore` method was used to determine which packages in the node_modules directory should be parsed by the babel-loader. The react-components package was the only one leveraging this functionality and has since been updated to build before being published. As a result, the ignore.js file has been removed.

See [this pull request](https://github.com/gas-buddy/babel-preset-gasbuddy/pull/11) for more information.