### PR TITLE
Change chunkhash to contenthash

### DIFF
--- a/src/webpack/config.js
+++ b/src/webpack/config.js
@@ -32,7 +32,7 @@ export function webpackConfig(optionsOrNull) {
       client: path.resolve('./src/client'),
     },
     output: options.output || {
-      filename: isProd ? '[name].[chunkhash].js' : '[name].bundle.js',
+      filename: isProd ? '[name].[contenthash].js' : '[name].bundle.js',
       publicPath: '/s/',
       path: path.resolve('./build-static'),
     },
@@ -125,7 +125,7 @@ export function webpackConfig(optionsOrNull) {
     // fix plugins for prod
     plugins.push(
       new MiniCssExtractPlugin({
-        filename: isProd ? '[name].[chunkhash].css' : '[name].bundle.css',
+        filename: isProd ? '[name].[contenthash].css' : '[name].bundle.css',
         ...options.miniCss,
       }),
     );


### PR DESCRIPTION
When using `[chunkhash]`, the hash included in the filename is specific to the chunk's entrypoint, which means that a single change in a single file could automatically create new filenames for all files within the chunk, invalidating cache unnecessarily. I've changed it to use `[contenthash]` which is the most effective hash to use for caching.

See https://github.com/webpack/webpack.js.org/issues/2096 for more.