### PR TITLE
Move postcss config to file

### DIFF
--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,13 @@
+module.exports = {
+  plugins: {
+    'postcss-import': {},
+    'postcss-preset-env': {
+      // If you don't set this, you get the GB preset default,
+      // which is fine in most cases
+      browsers: process.env.BROWSER_SUPPORT,
+      // Setting to stage 1 for now so we don't break functionality
+      // that worked with postcss-cssnext
+      stage: 1,
+    },
+  },
+};

--- a/src/webpack/config.js
+++ b/src/webpack/config.js
@@ -79,19 +79,9 @@ export function webpackConfig(optionsOrNull) {
         {
           loader: 'postcss-loader',
           options: {
-            plugins: () => [
-              // eslint-disable-next-line global-require
-              require('postcss-import'),
-              // eslint-disable-next-line global-require
-              require('postcss-preset-env')({
-                // If you don't set this, you get the GB preset default,
-                // which is fine in most cases
-                browsers: process.env.BROWSER_SUPPORT,
-                // Setting to stage 1 for now so we don't break functionality
-                // that worked with postcss-cssnext
-                stage: 1,
-              }),
-            ],
+            config: {
+              path: path.resolve(__dirname, '../../'),
+            },
           },
         },
       ],


### PR DESCRIPTION
This will allow us to overwrite the postcss configuration by setting our own postcss.config.js at the library/application level.